### PR TITLE
[TICKET 016] Add formatting and linting setup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{js,jsx,ts,tsx,json,css,html,yaml,yml,toml,md}]
+indent_style = space
+indent_size = 2
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,34 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.6
+    hooks:
+      - id: ruff
+        args: [--fix]
+        files: ^(api|pipeline)/
+      - id: ruff-format
+        files: ^(api|pipeline)/
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict
+
+  - repo: local
+    hooks:
+      - id: eslint
+        name: ESLint
+        language: node
+        entry: bash -c 'cd dashboard && npm run lint'
+        files: ^dashboard/src/.*\.[jt]sx?$
+        pass_filenames: false
+
+      - id: prettier
+        name: Prettier
+        language: node
+        entry: bash -c 'cd dashboard && npm run format:check'
+        files: ^dashboard/src/.*\.[jt]sx?$
+        pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+.PHONY: lint format check lint-py lint-js format-py format-js
+
+# Run all linters
+lint: lint-py lint-js
+
+# Run all formatters
+format: format-py format-js
+
+# Check all formatting without modifying files
+check: check-py check-js
+
+# Python linting with Ruff
+lint-py:
+	ruff check api/ pipeline/
+
+# JavaScript/TypeScript linting with ESLint
+lint-js:
+	cd dashboard && npm run lint
+
+# Python formatting with Ruff
+format-py:
+	ruff format api/ pipeline/
+
+# JavaScript/TypeScript formatting with Prettier
+format-js:
+	cd dashboard && npm run format
+
+# Check Python formatting (no modifications)
+check-py:
+	ruff check api/ pipeline/
+	ruff format --check api/ pipeline/
+
+# Check JS formatting (no modifications)
+check-js:
+	cd dashboard && npm run format:check && npm run lint

--- a/README.md
+++ b/README.md
@@ -48,3 +48,64 @@ To also remove the database volume:
 ```bash
 docker-compose down -v
 ```
+
+## Code quality
+
+### Python (api/ and pipeline/)
+
+Linting and formatting is handled by [Ruff](https://docs.astral.sh/ruff/).
+Configuration lives in `pyproject.toml` at the repo root.
+
+```bash
+# Lint
+make lint-py
+
+# Format
+make format-py
+
+# Check formatting without modifying files
+make check-py
+```
+
+### JavaScript / TypeScript (dashboard/)
+
+Linting is handled by [ESLint](https://eslint.org/) with plugins for React,
+SonarJS (cognitive complexity), Unicorn, and unused-imports.
+Formatting is handled by [Prettier](https://prettier.io/).
+
+```bash
+cd dashboard
+
+# Install dependencies (first time)
+npm install
+
+# Lint
+npm run lint
+
+# Format
+npm run format
+
+# Check formatting without modifying files
+npm run format:check
+```
+
+### Root-level orchestration
+
+Run everything at once from the repo root:
+
+```bash
+make lint     # lint Python + JS
+make format   # format Python + JS
+make check    # check Python + JS without modifying files
+```
+
+### Pre-commit hooks (optional)
+
+Install [pre-commit](https://pre-commit.com/) and set up the hooks:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Hooks will run Ruff, Prettier, and ESLint automatically before each commit.

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,3 +3,4 @@ uvicorn==0.34.0
 sqlalchemy==2.0.36
 psycopg2-binary==2.9.10
 pydantic==2.10.3
+ruff==0.9.6

--- a/dashboard/.prettierignore
+++ b/dashboard/.prettierignore
@@ -1,0 +1,3 @@
+dist
+design
+node_modules

--- a/dashboard/.prettierrc
+++ b/dashboard/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "printWidth": 100,
+  "tabWidth": 2,
+  "semi": true,
+  "trailingComma": "all"
+}

--- a/dashboard/eslint.config.js
+++ b/dashboard/eslint.config.js
@@ -1,0 +1,37 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint';
+import sonarjs from 'eslint-plugin-sonarjs';
+import unicorn from 'eslint-plugin-unicorn';
+import unusedImports from 'eslint-plugin-unused-imports';
+
+export default tseslint.config(
+  { ignores: ['dist', 'design'] },
+  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    files: ['**/*.{js,jsx,ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
+    plugins: {
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+      sonarjs,
+      unicorn,
+      'unused-imports': unusedImports,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+      'sonarjs/cognitive-complexity': ['error', 15],
+      'unused-imports/no-unused-imports': 'error',
+      'unused-imports/no-unused-vars': [
+        'warn',
+        { vars: 'all', varsIgnorePattern: '^_', args: 'after-used', argsIgnorePattern: '^_' },
+      ],
+    },
+  },
+);

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -6,16 +6,30 @@
   "scripts": {
     "dev": "vite --host",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@eslint/js": "^9.17.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",
+    "eslint": "^9.17.0",
+    "eslint-plugin-react-hooks": "^5.0.0",
+    "eslint-plugin-react-refresh": "^0.4.16",
+    "eslint-plugin-sonarjs": "^3.0.1",
+    "eslint-plugin-unicorn": "^56.0.1",
+    "eslint-plugin-unused-imports": "^4.1.4",
+    "globals": "^15.14.0",
+    "prettier": "^3.4.2",
+    "typescript-eslint": "^8.18.2",
     "vite": "^6.0.3"
   }
 }

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -7,3 +7,4 @@ sqlalchemy==2.0.36
 psycopg2-binary==2.9.10
 apscheduler==3.10.4
 requests==2.32.3
+ruff==0.9.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.ruff]
+line-length = 88
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "B", "SIM", "C4", "RUF"]
+ignore = []
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]


### PR DESCRIPTION
## Summary

- Added root `pyproject.toml` configuring Ruff with rule sets E, F, W, I, UP, B, SIM, C4, RUF; line-length 88; Python 3.12 target
- Added `ruff==0.9.6` to `api/` and `pipeline/` requirements
- Added ESLint flat config (`eslint.config.js`) with react-hooks, react-refresh, sonarjs (cognitive complexity ≤15), unicorn, and unused-imports plugins
- Added Prettier config (single quotes, 100-char width, 2-space indent)
- Added `lint`, `lint:fix`, `format`, `format:check` npm scripts to `dashboard/package.json`
- Added root `Makefile` with `lint`, `format`, `check` targets for both Python and JS
- Added `.editorconfig` enforcing UTF-8, LF endings, and language-specific indentation
- Added `.pre-commit-config.yaml` wiring Ruff, pre-commit-hooks, ESLint, and Prettier
- Updated README with a Code Quality section documenting all tooling and setup steps

## Acceptance criteria

- [x] Zero Ruff lint errors on existing `api/` and `pipeline/` code
- [x] Ruff format is idempotent on existing Python code
- [x] ESLint flat config in place with sonarjs cognitive complexity and unused-imports rules enforced
- [x] Prettier config in place; `format:check` exits non-zero on violations
- [x] `make lint / format / check` orchestrate both Python and JS from the repo root
- [x] `.editorconfig` covers all file types with correct indentation and line endings
- [x] Pre-commit hooks configured and documented in README

Closes #16
