### PR TITLE
[TICKET 008] Generate pre-race predictions

### DIFF
--- a/pipeline/ml/features.py
+++ b/pipeline/ml/features.py
@@ -1,0 +1,19 @@
+"""Shared ML utilities for the pipeline.ml package."""
+
+from pathlib import Path
+
+import pandas as pd
+
+ARTIFACTS_DIR = Path(__file__).resolve().parent / "artifacts"
+
+
+def prepare_features(df: pd.DataFrame) -> pd.DataFrame:
+    """Encode categorical columns and convert booleans for XGBoost.
+
+    Used by both the training and prediction pipelines to ensure
+    identical pre-processing at train and inference time.
+    """
+    df = df.copy()
+    df["circuit_type"] = df["circuit_type"].astype("category")
+    df["is_wet_race_forecast"] = df["is_wet_race_forecast"].astype(int)
+    return df

--- a/pipeline/ml/predict.py
+++ b/pipeline/ml/predict.py
@@ -12,11 +12,10 @@ from sqlalchemy.engine import Engine
 from xgboost import XGBRegressor
 
 from pipeline.ingest.upsert_helpers import get_engine
+from pipeline.ml.features import ARTIFACTS_DIR, prepare_features
 from pipeline.ml.train import FEATURE_COLS
 
 logger = logging.getLogger(__name__)
-
-ARTIFACTS_DIR = Path(__file__).resolve().parent / "artifacts"
 
 
 def load_model(path: Path) -> XGBRegressor:
@@ -32,53 +31,58 @@ def load_model(path: Path) -> XGBRegressor:
 def load_features(engine: Engine, race_id: int) -> pd.DataFrame:
     """Load feature rows from the features table for a given race.
 
+    Fetches features and qualifying results separately, then merges them in
+    Python so that any drivers missing from qualifying_results are detected
+    and logged rather than silently dropped.
+
     Returns a DataFrame with one row per driver, containing the
     feature columns expected by the model.
     """
     with engine.connect() as conn:
-        df = pd.read_sql(
-            text(
-                """
-                SELECT f.driver_id, f.feature_data,
-                       qr.constructor_id
-                FROM features f
-                JOIN qualifying_results qr
-                  ON qr.race_id = f.race_id AND qr.driver_id = f.driver_id
-                WHERE f.race_id = :race_id
-                """
-            ),
+        features_raw = pd.read_sql(
+            text("SELECT driver_id, feature_data FROM features WHERE race_id = :race_id"),
             conn,
             params={"race_id": race_id},
         )
-    if df.empty:
+        qualifying_raw = pd.read_sql(
+            text("SELECT driver_id, constructor_id FROM qualifying_results WHERE race_id = :race_id"),
+            conn,
+            params={"race_id": race_id},
+        )
+
+    if features_raw.empty:
         raise ValueError(f"No features found for race_id={race_id}")
 
     # Expand the JSONB feature_data column into separate columns.
-    feature_records = pd.json_normalize(df["feature_data"])
-    result = pd.concat(
-        [df[["driver_id", "constructor_id"]].reset_index(drop=True), feature_records],
+    feature_records = pd.json_normalize(features_raw["feature_data"])
+    expanded = pd.concat(
+        [features_raw[["driver_id"]].reset_index(drop=True), feature_records],
         axis=1,
     )
+
+    result = expanded.merge(qualifying_raw, on="driver_id", how="inner")
+
+    dropped = len(expanded) - len(result)
+    if dropped > 0:
+        logger.warning(
+            "%d driver(s) dropped for race_id=%d: present in features but missing from qualifying_results",
+            dropped,
+            race_id,
+        )
+
     logger.info("Loaded features for %d drivers (race_id=%d)", len(result), race_id)
     return result
-
-
-def prepare_prediction_features(df: pd.DataFrame) -> pd.DataFrame:
-    """Prepare feature columns for model prediction (same encoding as training)."""
-    df = df.copy()
-    df["circuit_type"] = df["circuit_type"].astype("category")
-    df["is_wet_race_forecast"] = df["is_wet_race_forecast"].astype(int)
-    return df
 
 
 def normalise_positions(raw_predictions: np.ndarray) -> list[int]:
     """Convert raw model outputs to unique integer positions 1..N.
 
     Ranks the raw predictions (lower = better position) and assigns
-    integer positions with no ties.
+    integer positions with no ties. Using kind="stable" ensures
+    tie-breaking is deterministic.
     """
     # argsort of argsort gives the rank (0-indexed)
-    order = raw_predictions.argsort().argsort()
+    order = raw_predictions.argsort(kind="stable").argsort(kind="stable")
     return [int(rank) + 1 for rank in order]
 
 
@@ -98,13 +102,13 @@ def store_predictions(
         {
             "race_id": race_id,
             "model_version_id": model_version_id,
-            "driver_id": int(row["driver_id"]),
-            "constructor_id": int(row["constructor_id"]),
-            "predicted_position": int(row["predicted_position"]),
+            "driver_id": int(rec["driver_id"]),
+            "constructor_id": int(rec["constructor_id"]),
+            "predicted_position": int(rec["predicted_position"]),
             "confidence_score": None,
             "created_at": now,
         }
-        for _, row in predictions.iterrows()
+        for rec in predictions.to_dict("records")
     ]
 
     with engine.begin() as conn:
@@ -150,11 +154,16 @@ def run(
 
     model = load_model(model_path)
     features_df = load_features(engine, race_id)
-    prepared = prepare_prediction_features(features_df)
+    prepared = prepare_features(features_df)
+
+    missing = [c for c in FEATURE_COLS if c not in prepared.columns]
+    if missing:
+        raise ValueError(f"Feature columns missing from loaded data: {missing}")
 
     raw_preds = model.predict(prepared[FEATURE_COLS])
     positions = normalise_positions(raw_preds)
 
+    features_df = features_df.reset_index(drop=True)
     features_df["predicted_position"] = positions
 
     result = features_df[["driver_id", "constructor_id", "predicted_position"]]

--- a/pipeline/ml/train.py
+++ b/pipeline/ml/train.py
@@ -11,10 +11,10 @@ from sqlalchemy.engine import Engine
 from xgboost import XGBRegressor
 
 from pipeline.ingest.upsert_helpers import get_engine
+from pipeline.ml.features import ARTIFACTS_DIR, prepare_features
 
 logger = logging.getLogger(__name__)
 
-ARTIFACTS_DIR = Path(__file__).resolve().parent / "artifacts"
 DATA_DIR = Path(__file__).resolve().parent.parent / "data"
 
 FEATURE_COLS = [
@@ -75,12 +75,9 @@ def attach_targets(features_df: pd.DataFrame, engine: Engine) -> pd.DataFrame:
     return merged
 
 
-def prepare_features(df: pd.DataFrame) -> pd.DataFrame:
-    """Encode categorical columns and convert booleans for XGBoost."""
-    df = df.copy()
-    df["circuit_type"] = df["circuit_type"].astype("category")
-    df["is_wet_race_forecast"] = df["is_wet_race_forecast"].astype(int)
-    return df
+# prepare_features is imported from pipeline.ml.features above and re-exported
+# here so that existing callers (e.g. test_train.py) can still import it from
+# this module without change.
 
 
 def train_model(

--- a/pipeline/tests/test_predict.py
+++ b/pipeline/tests/test_predict.py
@@ -7,11 +7,11 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from pipeline.ml.features import prepare_features
 from pipeline.ml.predict import (
     load_features,
     load_model,
     normalise_positions,
-    prepare_prediction_features,
     run,
     store_predictions,
 )
@@ -93,15 +93,23 @@ def test_load_features_empty():
 def test_load_features_success():
     fd1 = _make_feature_data()
     fd2 = _make_feature_data()
-    db_df = pd.DataFrame(
+    features_db_df = pd.DataFrame(
         {
             "driver_id": [1, 2],
-            "constructor_id": [10, 20],
             "feature_data": [fd1, fd2],
         }
     )
+    qualifying_db_df = pd.DataFrame(
+        {
+            "driver_id": [1, 2],
+            "constructor_id": [10, 20],
+        }
+    )
     engine = MagicMock()
-    with patch("pipeline.ml.predict.pd.read_sql", return_value=db_df):
+    with patch(
+        "pipeline.ml.predict.pd.read_sql",
+        side_effect=[features_db_df, qualifying_db_df],
+    ):
         result = load_features(engine, race_id=1)
 
     assert len(result) == 2
@@ -111,14 +119,45 @@ def test_load_features_success():
         assert col in result.columns, f"Missing feature column: {col}"
 
 
+def test_load_features_warns_on_missing_qualifying(caplog):
+    """load_features logs a warning when a driver has features but no qualifying result."""
+    import logging
+
+    fd1 = _make_feature_data()
+    fd2 = _make_feature_data()
+    features_db_df = pd.DataFrame(
+        {
+            "driver_id": [1, 2],
+            "feature_data": [fd1, fd2],
+        }
+    )
+    # Only driver 1 has a qualifying result; driver 2 will be dropped.
+    qualifying_db_df = pd.DataFrame(
+        {
+            "driver_id": [1],
+            "constructor_id": [10],
+        }
+    )
+    engine = MagicMock()
+    with patch(
+        "pipeline.ml.predict.pd.read_sql",
+        side_effect=[features_db_df, qualifying_db_df],
+    ):
+        with caplog.at_level(logging.WARNING, logger="pipeline.ml.predict"):
+            result = load_features(engine, race_id=1)
+
+    assert len(result) == 1
+    assert any("dropped" in record.message for record in caplog.records)
+
+
 # ---------------------------------------------------------------------------
-# prepare_prediction_features
+# prepare_features
 # ---------------------------------------------------------------------------
 
 
-def test_prepare_prediction_features():
+def test_prepare_features():
     df = _make_features_df(3)
-    result = prepare_prediction_features(df)
+    result = prepare_features(df)
     assert result["circuit_type"].dtype.name == "category"
     assert result["is_wet_race_forecast"].dtype in (np.int64, np.int32, int)
 
@@ -152,6 +191,14 @@ def test_normalise_positions_close_values():
     raw = np.array([5.001, 5.002, 5.003])
     positions = normalise_positions(raw)
     assert sorted(positions) == [1, 2, 3]
+
+
+def test_normalise_positions_stability():
+    """Identical inputs produce identical positions across repeated calls."""
+    raw = np.array([5.0, 5.0, 3.0])
+    assert normalise_positions(raw) == normalise_positions(raw)
+    # The element with the lowest value (3.0, index 2) should always be position 1.
+    assert normalise_positions(raw)[2] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -216,3 +263,33 @@ def test_run_end_to_end(tmp_path):
     assert set(result.columns) == {"driver_id", "constructor_id", "predicted_position"}
     positions = sorted(result["predicted_position"].tolist())
     assert positions == [1, 2, 3, 4, 5]  # unique 1..N
+
+
+def test_run_raises_on_missing_feature_columns(tmp_path):
+    """run() raises ValueError when loaded features are missing expected columns."""
+    from xgboost import XGBRegressor
+
+    n_features = len(FEATURE_COLS)
+    X = np.random.RandomState(42).rand(40, n_features)
+    y = np.random.RandomState(42).randint(1, 21, size=40).astype(float)
+    model = XGBRegressor(n_estimators=10, random_state=42, enable_categorical=False)
+    model.fit(X, y)
+    model_path = tmp_path / "model.json"
+    model.save_model(str(model_path))
+
+    # Drop one required column to trigger the guard.
+    incomplete_df = _make_features_df(3).drop(columns=["grid_position"])
+
+    mock_conn = MagicMock()
+    mock_engine = MagicMock()
+    mock_engine.begin.return_value.__enter__ = MagicMock(return_value=mock_conn)
+    mock_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+
+    with patch("pipeline.ml.predict.load_features", return_value=incomplete_df):
+        with pytest.raises(ValueError, match="Feature columns missing from loaded data"):
+            run(
+                race_id=1,
+                model_version_id=1,
+                model_path=model_path,
+                engine=mock_engine,
+            )


### PR DESCRIPTION
Add pipeline/ml/predict.py that loads a trained XGBoost model, reads
pre-race features from the database, predicts finishing positions, and
stores them in the predictions table.

Key functionality:
- Accepts --race-id and --model-version-id CLI arguments
- Loads features from the features table for the given race
- Loads the model artifact from disk
- Normalises raw predictions to unique integer positions 1..N
- Upserts results into the predictions table with created_at timestamp
- Supports re-running without creating duplicates (ON CONFLICT upsert)

Includes comprehensive tests covering all public functions and an
end-to-end integration test with a real model and mocked database.