### PR TITLE
TICKET 009 — Post-race evaluation

### DIFF
--- a/pipeline/ml/evaluate.py
+++ b/pipeline/ml/evaluate.py
@@ -33,7 +33,10 @@ def load_comparison(engine: Engine, race_id: int, model_version_id: int) -> pd.D
         JOIN race_results rr
           ON rr.race_id = p.race_id
          AND rr.driver_id = p.driver_id
-        WHERE p.race_id = :race_id
+        JOIN races r
+          ON r.id = p.race_id
+        WHERE r.is_completed = TRUE
+          AND p.race_id = :race_id
           AND p.model_version_id = :model_version_id
         """
     )
@@ -52,11 +55,11 @@ def load_comparison(engine: Engine, race_id: int, model_version_id: int) -> pd.D
     return df
 
 
-def compute_metrics(df: pd.DataFrame) -> dict:
+def compute_metrics(df: pd.DataFrame) -> dict[str, float]:
     """Compute evaluation metrics from a prediction-vs-result DataFrame.
 
     DNF drivers (``finish_position`` is NULL) are excluded from position-based
-    accuracy metrics but included in the total driver count for logging.
+    accuracy metrics.
 
     Returns a dict with keys:
         exact_position_accuracy, top3_accuracy, mean_position_error
@@ -100,7 +103,7 @@ def store_metrics(
     engine: Engine,
     race_id: int,
     model_version_id: int,
-    metrics: dict,
+    metrics: dict[str, float],
 ) -> None:
     """Insert evaluation metrics into the evaluation_metrics table.
 
@@ -145,7 +148,7 @@ def store_metrics(
 def log_summary(
     race_id: int,
     model_version_id: int,
-    metrics: dict,
+    metrics: dict[str, float],
     total_drivers: int,
     classified_drivers: int,
 ) -> None:
@@ -168,7 +171,7 @@ def run(
     race_id: int,
     model_version_id: int,
     engine: Engine | None = None,
-) -> dict:
+) -> dict[str, float]:
     """End-to-end evaluation pipeline for a single race.
 
     Returns the computed metrics dict.

--- a/pipeline/tests/test_evaluate.py
+++ b/pipeline/tests/test_evaluate.py
@@ -73,7 +73,7 @@ def test_compute_metrics_perfect_predictions():
     assert metrics["mean_position_error"] == 0.0
 
 
-def test_compute_metrics_no_correct():
+def test_compute_metrics_mostly_wrong():
     df = _make_comparison_df([5, 4, 3, 2, 1], [1, 2, 3, 4, 5])
     metrics = compute_metrics(df)
 


### PR DESCRIPTION
## Summary
- Added `pipeline/ml/evaluate.py` — compares predictions to actual race results and computes three accuracy metrics (exact position accuracy, top-3 accuracy, mean position error)
- Stores results in the `evaluation_metrics` table with upsert semantics
- DNF drivers are excluded from position-based metrics but kept in the dataset
- Logs a human-readable summary to console
- CLI: `python -m pipeline.ml.evaluate --race-id <id> --model-version-id <id>`

## Test plan
- [x] 9 unit tests covering all metric calculations, DNF handling, DB storage, and end-to-end flow
- [x] All 125 pipeline tests pass
- [x] `ruff check` and `ruff format --check` pass cleanly

Closes #9