### PR TITLE
TICKET 028 — Fix race hero location — show city not race name

### DIFF
--- a/api/routes/races.py
+++ b/api/routes/races.py
@@ -64,6 +64,7 @@ def list_races(season: int, db: Session = Depends(get_db)):
             round=r.round,
             name=r.name,
             circuit=r.circuit.name,
+            city=r.circuit.city,
             country=r.circuit.country,
             date=r.date,
             is_completed=r.is_completed,

--- a/api/schemas/races.py
+++ b/api/schemas/races.py
@@ -8,6 +8,7 @@ class RaceListItem(BaseModel):
     round: int
     name: str
     circuit: str
+    city: str
     country: str
     date: datetime.date
     is_completed: bool

--- a/dashboard/src/components/prediction/RaceHero.tsx
+++ b/dashboard/src/components/prediction/RaceHero.tsx
@@ -66,7 +66,7 @@ export function RaceHero({ race, predictions }: Props) {
             </h1>
             <div className="flex items-center gap-4 mt-1.5">
               <span className="flex items-center gap-1.5 text-[#6b7280] text-xs">
-                <MapPin size={11} /> {race.circuit}
+                <MapPin size={11} /> {race.city}
               </span>
               <span className="flex items-center gap-1.5 text-[#6b7280] text-xs">
                 <Calendar size={11} /> {formatDate(race.date)}

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -5,6 +5,7 @@ export interface ApiRaceListItem {
   round: number;
   name: string;
   circuit: string;
+  city: string;
   country: string;
   date: string;
   is_completed: boolean;


### PR DESCRIPTION
## Summary
- Added `city: str` to `RaceListItem` schema and populates it from `circuit.city`
- Added `city` field to `ApiRaceListItem` TypeScript interface
- `RaceHero` now renders `race.city` (e.g. \"Melbourne\") under the map pin instead of `race.circuit` (which was the duplicate race event name)

## Acceptance criteria
- ✅ Map pin shows city name (e.g. \"Melbourne\"), not the race event name
- ✅ Map pin content is visually distinct from the heading above it (existing styling unchanged)

Closes #50