### PR TITLE
TICKET 037 — Tyre compound nominations and degradation as features

### DIFF
--- a/db/migrations/013_add_race_tyre_data.sql
+++ b/db/migrations/013_add_race_tyre_data.sql
@@ -1,0 +1,16 @@
+-- Migration 013: add race_tyre_data table
+-- Stores per-driver lap counts for each tyre compound used in a race session.
+-- Used to compute circuit_tyre_degradation_index and
+-- constructor_hard_compound_avg_position ML features.
+
+CREATE TABLE race_tyre_data (
+    id          SERIAL  PRIMARY KEY,
+    race_id     INTEGER NOT NULL REFERENCES races(id),
+    driver_id   INTEGER NOT NULL REFERENCES drivers(id),
+    compound    TEXT    NOT NULL,  -- 'SOFT', 'MEDIUM', 'HARD', 'INTERMEDIATE', 'WET'
+    lap_count   INTEGER NOT NULL,
+    UNIQUE (race_id, driver_id, compound)
+);
+
+CREATE INDEX idx_race_tyre_data_race   ON race_tyre_data (race_id);
+CREATE INDEX idx_race_tyre_data_driver ON race_tyre_data (driver_id);

--- a/pipeline/bootstrap.py
+++ b/pipeline/bootstrap.py
@@ -26,6 +26,7 @@ from pipeline.features.builder import build_features_for_race, export_parquet
 from pipeline.ingest.calendar_sync import sync_season_calendar
 from pipeline.ingest.fetch_qualifying import ingest_event as ingest_qualifying
 from pipeline.ingest.fetch_results import ingest_event as ingest_results
+from pipeline.ingest.fetch_tyre_data import ingest_event as ingest_tyre_data
 from pipeline.ingest.upsert_helpers import get_engine
 from pipeline.maintenance.driver_metadata import backfill_driver_numbers
 from pipeline.ml.predict import run as predict
@@ -101,6 +102,10 @@ def main() -> None:
             except Exception as exc:
                 logger.warning("      Results ingest failed: %s", exc)
             try:
+                ingest_tyre_data(hist_season, round_num, engine)
+            except Exception as exc:
+                logger.warning("      Tyre data ingest failed: %s", exc)
+            try:
                 df = build_features_for_race(race_id, engine)
                 if not df.empty:
                     export_parquet(df, race_id)
@@ -124,6 +129,10 @@ def main() -> None:
             ingest_results(SEASON, round_num, engine)
         except Exception as exc:
             logger.warning("    Results ingest failed: %s", exc)
+        try:
+            ingest_tyre_data(SEASON, round_num, engine)
+        except Exception as exc:
+            logger.warning("    Tyre data ingest failed: %s", exc)
 
     # Also ingest qualifying for the next upcoming race (needed for grid positions)
     if next_event:

--- a/pipeline/features/builder.py
+++ b/pipeline/features/builder.py
@@ -447,6 +447,92 @@ def _driver_avg_sector2_time_at_circuit(
     return float(val) if val is not None else None
 
 
+def _circuit_tyre_degradation_index(conn: Connection, circuit_id: int, race_date: object) -> int:
+    """Ordinal encoding of historically high/medium/low tyre degradation at a circuit.
+
+    Computed as the average proportion of HARD compound laps across all completed
+    races at this circuit before race_date.  Thresholds:
+        < 0.30  → 0 (low degradation, e.g. Monza)
+        0.30–0.50 → 1 (medium)
+        > 0.50  → 2 (high degradation, e.g. Barcelona)
+
+    Returns 1 (neutral) when no prior tyre data exists for the circuit.
+    """
+    val = conn.execute(
+        text(
+            """
+            SELECT AVG(sub.hard_ratio)
+            FROM (
+                SELECT
+                    SUM(rtd.lap_count) FILTER (WHERE rtd.compound = 'HARD')::float
+                    / NULLIF(SUM(rtd.lap_count), 0) AS hard_ratio
+                FROM race_tyre_data rtd
+                JOIN races r ON r.id = rtd.race_id
+                WHERE r.circuit_id = :cid
+                  AND r.date < :race_date
+                  AND r.is_completed = TRUE
+                GROUP BY r.id
+            ) sub
+            """
+        ),
+        {"cid": circuit_id, "race_date": race_date},
+    ).scalar()
+    if val is None:
+        return 1
+    ratio = float(val)
+    if ratio < 0.30:
+        return 0
+    if ratio <= 0.50:
+        return 1
+    return 2
+
+
+def _constructor_hard_compound_avg_position(
+    conn: Connection, constructor_id: int, race_date: object
+) -> float | None:
+    """Historical average finish position for a constructor at high-degradation circuits.
+
+    A circuit is considered high-degradation when the average proportion of HARD
+    compound laps across its historical races exceeds 0.50 (i.e. the same threshold
+    used for circuit_tyre_degradation_index == 2).
+
+    Returns None when the constructor has no results at high-degradation circuits.
+    """
+    val = conn.execute(
+        text(
+            """
+            SELECT AVG(rr.finish_position)
+            FROM race_results rr
+            JOIN races r ON r.id = rr.race_id
+            WHERE rr.constructor_id = :cid
+              AND rr.finish_position IS NOT NULL
+              AND r.date < :race_date
+              AND r.is_completed = TRUE
+              AND r.circuit_id IN (
+                  SELECT circuit_id
+                  FROM (
+                      SELECT
+                          r2.circuit_id,
+                          AVG(
+                              SUM(rtd.lap_count) FILTER (WHERE rtd.compound = 'HARD')::float
+                              / NULLIF(SUM(rtd.lap_count), 0)
+                          ) AS avg_hard_ratio
+                      FROM race_tyre_data rtd
+                      JOIN races r2 ON r2.id = rtd.race_id
+                      WHERE r2.date < :race_date
+                        AND r2.is_completed = TRUE
+                      GROUP BY r2.circuit_id, r2.id
+                  ) per_circuit
+                  GROUP BY circuit_id
+                  HAVING AVG(avg_hard_ratio) > 0.50
+              )
+            """
+        ),
+        {"cid": constructor_id, "race_date": race_date},
+    ).scalar()
+    return float(val) if val is not None else None
+
+
 def _constructor_avg_fp2_pace_at_circuit(
     conn: Connection, constructor_id: int, circuit_id: int, race_date: object
 ) -> float | None:
@@ -551,6 +637,9 @@ def build_features_for_race(race_id: int, engine: Engine) -> pd.DataFrame:
         driver_champ_default = 1 if not driver_champ else len(driver_champ) + 1
         constructor_champ_default = 1 if not constructor_champ else len(constructor_champ) + 1
 
+        # Circuit-level tyre degradation index — same value for every driver this race.
+        degradation_idx = _circuit_tyre_degradation_index(conn, race["circuit_id"], race["date"])
+
         rows: list[dict] = []
         for entry in drivers:
             did = entry["driver_id"]
@@ -590,6 +679,13 @@ def build_features_for_race(race_id: int, engine: Engine) -> pd.DataFrame:
                 "constructor_avg_fp2_pace_at_circuit": _constructor_avg_fp2_pace_at_circuit(
                     conn, cid, race["circuit_id"], race["date"]
                 ),
+                # Tyre features.
+                # circuit_tyre_degradation_index is a race-level constant (same for all drivers).
+                # constructor_hard_compound_avg_position may be None; imputed with median below.
+                "circuit_tyre_degradation_index": degradation_idx,
+                "constructor_hard_compound_avg_position": _constructor_hard_compound_avg_position(
+                    conn, cid, race["date"]
+                ),
             }
 
             rows.append({"race_id": race_id, "driver_id": did, **feature_data})
@@ -598,7 +694,11 @@ def build_features_for_race(race_id: int, engine: Engine) -> pd.DataFrame:
         # If no driver has historical data (e.g. a new circuit), default to 1.0.
         # Note: 1.0 is the fastest possible ratio, so all drivers receive the same
         # value and gain no relative advantage over each other from this feature.
-        for col in ("driver_avg_sector2_time_at_circuit", "constructor_avg_fp2_pace_at_circuit"):
+        for col in (
+            "driver_avg_sector2_time_at_circuit",
+            "constructor_avg_fp2_pace_at_circuit",
+            "constructor_hard_compound_avg_position",
+        ):
             non_null = [r[col] for r in rows if r[col] is not None]
             fill = statistics.median(non_null) if non_null else 1.0
             for r in rows:

--- a/pipeline/features/builder.py
+++ b/pipeline/features/builder.py
@@ -487,9 +487,7 @@ def _circuit_tyre_degradation_index(conn: Connection, circuit_id: int, race_date
     return 2
 
 
-def _constructor_hard_compound_avg_position(
-    conn: Connection, constructor_id: int, race_date: object
-) -> float | None:
+def _constructor_hard_compound_avg_position(conn: Connection, constructor_id: int, race_date: object) -> float | None:
     """Historical average finish position for a constructor at high-degradation circuits.
 
     A circuit is considered high-degradation when the average proportion of HARD

--- a/pipeline/features/builder.py
+++ b/pipeline/features/builder.py
@@ -450,22 +450,24 @@ def _driver_avg_sector2_time_at_circuit(
 def _circuit_tyre_degradation_index(conn: Connection, circuit_id: int, race_date: object) -> int:
     """Ordinal encoding of historically high/medium/low tyre degradation at a circuit.
 
-    Computed as the average proportion of HARD compound laps across all completed
-    races at this circuit before race_date.  Thresholds:
-        < 0.30   -> 0 (low degradation, e.g. Monza)
-        0.30-0.50 -> 1 (medium)
-        > 0.50   -> 2 (high degradation, e.g. Barcelona)
+    Computed as the average number of distinct compounds used per driver across all
+    completed races at this circuit before race_date.  More compounds per driver
+    indicates more pit stops, which is a reliable proxy for tyre degradation.
+    Thresholds:
+        < 2.1  -> 0 (low degradation, e.g. Monza)
+        2.1-2.3 -> 1 (medium)
+        >= 2.3  -> 2 (high degradation, e.g. Barcelona)
 
     Returns 1 (neutral) when no prior tyre data exists for the circuit.
     """
     val = conn.execute(
         text(
             """
-            SELECT AVG(sub.hard_ratio)
+            SELECT AVG(sub.avg_compounds)
             FROM (
                 SELECT
-                    SUM(rtd.lap_count) FILTER (WHERE rtd.compound = 'HARD')::float
-                    / NULLIF(SUM(rtd.lap_count), 0) AS hard_ratio
+                    COUNT(DISTINCT (rtd.driver_id, rtd.compound))::float
+                    / NULLIF(COUNT(DISTINCT rtd.driver_id), 0) AS avg_compounds
                 FROM race_tyre_data rtd
                 JOIN races r ON r.id = rtd.race_id
                 WHERE r.circuit_id = :cid
@@ -479,10 +481,10 @@ def _circuit_tyre_degradation_index(conn: Connection, circuit_id: int, race_date
     ).scalar()
     if val is None:
         return 1
-    ratio = float(val)
-    if ratio < 0.30:
+    avg = float(val)
+    if avg < 2.1:
         return 0
-    if ratio <= 0.50:
+    if avg < 2.3:
         return 1
     return 2
 
@@ -490,9 +492,9 @@ def _circuit_tyre_degradation_index(conn: Connection, circuit_id: int, race_date
 def _constructor_hard_compound_avg_position(conn: Connection, constructor_id: int, race_date: object) -> float | None:
     """Historical average finish position for a constructor at high-degradation circuits.
 
-    A circuit is considered high-degradation when the average proportion of HARD
-    compound laps across its historical races exceeds 0.50 (i.e. the same threshold
-    used for circuit_tyre_degradation_index == 2).
+    A circuit is considered high-degradation when its average compounds-per-driver
+    across historical races is >= 2.3 (i.e. the same threshold used for
+    circuit_tyre_degradation_index == 2).
 
     Returns None when the constructor has no results at high-degradation circuits.
     """
@@ -511,10 +513,8 @@ def _constructor_hard_compound_avg_position(conn: Connection, constructor_id: in
                   FROM (
                       SELECT
                           r2.circuit_id,
-                          AVG(
-                              SUM(rtd.lap_count) FILTER (WHERE rtd.compound = 'HARD')::float
-                              / NULLIF(SUM(rtd.lap_count), 0)
-                          ) AS avg_hard_ratio
+                          COUNT(DISTINCT (rtd.driver_id, rtd.compound))::float
+                          / NULLIF(COUNT(DISTINCT rtd.driver_id), 0) AS avg_compounds
                       FROM race_tyre_data rtd
                       JOIN races r2 ON r2.id = rtd.race_id
                       WHERE r2.date < :race_date
@@ -522,7 +522,7 @@ def _constructor_hard_compound_avg_position(conn: Connection, constructor_id: in
                       GROUP BY r2.circuit_id, r2.id
                   ) per_circuit
                   GROUP BY circuit_id
-                  HAVING AVG(avg_hard_ratio) > 0.50
+                  HAVING AVG(avg_compounds) >= 2.3
               )
             """
         ),

--- a/pipeline/features/builder.py
+++ b/pipeline/features/builder.py
@@ -452,9 +452,9 @@ def _circuit_tyre_degradation_index(conn: Connection, circuit_id: int, race_date
 
     Computed as the average proportion of HARD compound laps across all completed
     races at this circuit before race_date.  Thresholds:
-        < 0.30  → 0 (low degradation, e.g. Monza)
-        0.30–0.50 → 1 (medium)
-        > 0.50  → 2 (high degradation, e.g. Barcelona)
+        < 0.30   -> 0 (low degradation, e.g. Monza)
+        0.30-0.50 -> 1 (medium)
+        > 0.50   -> 2 (high degradation, e.g. Barcelona)
 
     Returns 1 (neutral) when no prior tyre data exists for the circuit.
     """

--- a/pipeline/features/builder.py
+++ b/pipeline/features/builder.py
@@ -688,20 +688,30 @@ def build_features_for_race(race_id: int, engine: Engine) -> pd.DataFrame:
 
             rows.append({"race_id": race_id, "driver_id": did, **feature_data})
 
-        # Impute missing sector/FP2 features with the circuit median for this race.
-        # If no driver has historical data (e.g. a new circuit), default to 1.0.
-        # Note: 1.0 is the fastest possible ratio, so all drivers receive the same
-        # value and gain no relative advantage over each other from this feature.
+        # Impute missing sector/FP2 pace features with the circuit median for this
+        # race.  If no driver has historical data (e.g. a new circuit), default to
+        # 1.0 — the neutral "exactly at session pace" ratio, so all drivers receive
+        # the same value and gain no relative advantage from this feature.
         for col in (
             "driver_avg_sector2_time_at_circuit",
             "constructor_avg_fp2_pace_at_circuit",
-            "constructor_hard_compound_avg_position",
         ):
             non_null = [r[col] for r in rows if r[col] is not None]
             fill = statistics.median(non_null) if non_null else 1.0
             for r in rows:
                 if r[col] is None:
                     r[col] = fill
+
+        # Impute missing constructor hard-compound position with the race median.
+        # If no constructor has hard-compound circuit history, default to 10.0 —
+        # the neutral mid-field position — so no constructor gains a spurious
+        # advantage over another from missing data.
+        hc_col = "constructor_hard_compound_avg_position"
+        hc_non_null = [r[hc_col] for r in rows if r[hc_col] is not None]
+        hc_fill = statistics.median(hc_non_null) if hc_non_null else 10.0
+        for r in rows:
+            if r[hc_col] is None:
+                r[hc_col] = hc_fill
 
         skip = {"race_id", "driver_id"}
         for r in rows:

--- a/pipeline/ingest/fetch_tyre_data.py
+++ b/pipeline/ingest/fetch_tyre_data.py
@@ -1,7 +1,7 @@
 """Ingest per-driver tyre compound lap counts from race sessions using FastF1.
 
-Stores the number of laps each driver ran on each compound (SOFT, MEDIUM, HARD,
-INTERMEDIATE, WET) in the ``race_tyre_data`` table.  Used by the feature builder
+Stores the number of laps each driver ran on each dry compound (SOFT, MEDIUM,
+HARD) in the ``race_tyre_data`` table.  Used by the feature builder
 to compute ``circuit_tyre_degradation_index`` and
 ``constructor_hard_compound_avg_position``.
 
@@ -36,8 +36,10 @@ for _noisy in ("fastf1", "req", "core", "logger", "_api"):
     logging.getLogger(_noisy).setLevel(logging.CRITICAL)
 logger = logging.getLogger(__name__)
 
-# Compounds recognised as valid dry-tyre data.
-VALID_COMPOUNDS = {"SOFT", "MEDIUM", "HARD", "INTERMEDIATE", "WET"}
+# Dry-weather compounds only — INTERMEDIATE and WET are excluded because they
+# are driven by rain conditions, not tyre degradation characteristics, and
+# would inflate avg_compounds_per_driver at wet circuits.
+VALID_COMPOUNDS = {"SOFT", "MEDIUM", "HARD"}
 
 
 def upsert_tyre_data(
@@ -77,7 +79,7 @@ def _compound_counts_from_laps(laps: pd.DataFrame) -> dict[str, dict[str, int]]:
     return counts
 
 
-def _ingest_event(season: int, round_num: int, engine: Engine) -> bool:
+def ingest_event(season: int, round_num: int, engine: Engine) -> bool:
     """Load one race session and upsert compound lap counts into race_tyre_data.
 
     Returns True if any data was ingested.
@@ -149,7 +151,7 @@ def ingest_season(season: int, engine: Engine) -> None:
     schedule = fastf1.get_event_schedule(season, include_testing=False)
     logger.info("Season %d — %d race events found", season, len(schedule))
     for _, event in schedule.iterrows():
-        _ingest_event(season, int(event["RoundNumber"]), engine)
+        ingest_event(season, int(event["RoundNumber"]), engine)
     logger.info("Season %d tyre data ingestion complete.", season)
 
 
@@ -161,7 +163,7 @@ def main() -> None:
 
     engine = get_engine()
     if args.round is not None:
-        _ingest_event(args.season, args.round, engine)
+        ingest_event(args.season, args.round, engine)
     else:
         ingest_season(args.season, engine)
 

--- a/pipeline/ingest/fetch_tyre_data.py
+++ b/pipeline/ingest/fetch_tyre_data.py
@@ -1,0 +1,170 @@
+"""Ingest per-driver tyre compound lap counts from race sessions using FastF1.
+
+Stores the number of laps each driver ran on each compound (SOFT, MEDIUM, HARD,
+INTERMEDIATE, WET) in the ``race_tyre_data`` table.  Used by the feature builder
+to compute ``circuit_tyre_degradation_index`` and
+``constructor_hard_compound_avg_position``.
+
+Backfill ordering note
+----------------------
+``upsert_race`` is called with ``mark_completed=False``, so race rows created by
+this script alone will have ``is_completed = FALSE``.  All feature builder SQL
+queries filter ``r.is_completed = TRUE``, so those races will be invisible to
+training until ``fetch_results`` has also been run.  Always run ``fetch_results``
+before or after ``fetch_tyre_data`` when backfilling a season on a fresh database.
+"""
+
+import argparse
+import logging
+
+import fastf1
+import pandas as pd
+from sqlalchemy import text
+from sqlalchemy.engine import Connection, Engine
+
+from pipeline.ingest.upsert_helpers import (
+    get_engine,
+    upsert_circuit,
+    upsert_constructor,
+    upsert_driver,
+    upsert_driver_contract,
+    upsert_race,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+for _noisy in ("fastf1", "req", "core", "logger", "_api"):
+    logging.getLogger(_noisy).setLevel(logging.CRITICAL)
+logger = logging.getLogger(__name__)
+
+# Compounds recognised as valid dry-tyre data.
+VALID_COMPOUNDS = {"SOFT", "MEDIUM", "HARD", "INTERMEDIATE", "WET"}
+
+
+def upsert_tyre_data(
+    conn: Connection,
+    race_id: int,
+    driver_id: int,
+    compound: str,
+    lap_count: int,
+) -> None:
+    conn.execute(
+        text(
+            """
+            INSERT INTO race_tyre_data (race_id, driver_id, compound, lap_count)
+            VALUES (:race_id, :driver_id, :compound, :lap_count)
+            ON CONFLICT (race_id, driver_id, compound) DO UPDATE
+                SET lap_count = EXCLUDED.lap_count
+            """
+        ),
+        {
+            "race_id": race_id,
+            "driver_id": driver_id,
+            "compound": compound,
+            "lap_count": lap_count,
+        },
+    )
+
+
+def _compound_counts_from_laps(laps: pd.DataFrame) -> dict[str, dict[str, int]]:
+    """Return {driver_code: {compound: lap_count}} from a race laps DataFrame."""
+    if laps is None or laps.empty or "Compound" not in laps.columns:
+        return {}
+
+    counts: dict[str, dict[str, int]] = {}
+    valid = laps[laps["Compound"].isin(VALID_COMPOUNDS)]
+    for (driver_code, compound), grp in valid.groupby(["Driver", "Compound"]):
+        counts.setdefault(str(driver_code), {})[str(compound)] = len(grp)
+    return counts
+
+
+def _ingest_event(season: int, round_num: int, engine: Engine) -> bool:
+    """Load one race session and upsert compound lap counts into race_tyre_data.
+
+    Returns True if any data was ingested.
+    """
+    logger.info("Season %d round %d: loading race session for tyre data…", season, round_num)
+    try:
+        session = fastf1.get_session(season, round_num, "R")
+        session.load(laps=True, telemetry=False, weather=False, messages=False)
+    except Exception as exc:
+        logger.warning("Season %d round %d: failed to load race session — %s", season, round_num, exc)
+        return False
+
+    results: pd.DataFrame = session.results
+    if results is None or results.empty:
+        logger.warning("Season %d round %d: no results data", season, round_num)
+        return False
+
+    laps: pd.DataFrame = session.laps
+    if laps is None or laps.empty:
+        logger.warning("Season %d round %d: no lap data", season, round_num)
+        return False
+
+    event_name = session.event["EventName"]
+    event_date = session.event["EventDate"]
+    race_date = event_date.date() if hasattr(event_date, "date") else event_date
+
+    compound_counts = _compound_counts_from_laps(laps)
+    if not compound_counts:
+        logger.warning("Season %d round %d: no valid compound data in laps", season, round_num)
+        return False
+
+    ingested = 0
+    with engine.begin() as conn:
+        circuit_id = upsert_circuit(conn, session)
+        race_id = upsert_race(conn, season, round_num, event_name, circuit_id, race_date, mark_completed=False)
+
+        for _, row in results.iterrows():
+            driver_code = str(row.get("Abbreviation", ""))[:3]
+            if not driver_code:
+                continue
+
+            full_name = str(row.get("FullName", driver_code))
+            nationality = str(row.get("CountryCode", ""))
+            constructor_name = str(row.get("TeamName", "Unknown"))
+            constructor_nationality = str(row.get("TeamNationality", ""))
+            driver_number_raw = row.get("DriverNumber")
+            driver_number = int(driver_number_raw) if driver_number_raw is not None else None
+
+            driver_id = upsert_driver(conn, driver_code, full_name, nationality, driver_number)
+            constructor_id = upsert_constructor(conn, constructor_name, constructor_nationality)
+            upsert_driver_contract(conn, driver_id, constructor_id, season, round_num)
+
+            driver_compounds = compound_counts.get(driver_code, {})
+            for compound, lap_count in driver_compounds.items():
+                upsert_tyre_data(conn, race_id, driver_id, compound, lap_count)
+                ingested += 1
+
+    logger.info(
+        "Season %d round %d — %s: ingested %d tyre compound rows",
+        season,
+        round_num,
+        event_name,
+        ingested,
+    )
+    return ingested > 0
+
+
+def ingest_season(season: int, engine: Engine) -> None:
+    schedule = fastf1.get_event_schedule(season, include_testing=False)
+    logger.info("Season %d — %d race events found", season, len(schedule))
+    for _, event in schedule.iterrows():
+        _ingest_event(season, int(event["RoundNumber"]), engine)
+    logger.info("Season %d tyre data ingestion complete.", season)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Ingest F1 race tyre compound lap counts.")
+    parser.add_argument("--season", type=int, required=True, help="Season year, e.g. 2023")
+    parser.add_argument("--round", type=int, default=None, help="Single round number")
+    args = parser.parse_args()
+
+    engine = get_engine()
+    if args.round is not None:
+        _ingest_event(args.season, args.round, engine)
+    else:
+        ingest_season(args.season, engine)
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/ml/features.py
+++ b/pipeline/ml/features.py
@@ -58,6 +58,8 @@ def prepare_features(df: pd.DataFrame) -> pd.DataFrame:
         "constructor_dnf_rate_last_season",
         "driver_avg_sector2_time_at_circuit",
         "constructor_avg_fp2_pace_at_circuit",
+        "circuit_tyre_degradation_index",
+        "constructor_hard_compound_avg_position",
     ]
     for col in _numeric_cols:
         if col in df.columns:

--- a/pipeline/ml/train.py
+++ b/pipeline/ml/train.py
@@ -35,6 +35,8 @@ FEATURE_COLS = [
     "constructor_dnf_rate_last_season",
     "driver_avg_sector2_time_at_circuit",
     "constructor_avg_fp2_pace_at_circuit",
+    "circuit_tyre_degradation_index",
+    "constructor_hard_compound_avg_position",
 ]
 
 TARGET_COL = "finish_position"

--- a/pipeline/tests/test_builder.py
+++ b/pipeline/tests/test_builder.py
@@ -443,22 +443,22 @@ def test_sector_fp2_imputation_all_null_defaults_to_one():
 
 
 def test_circuit_tyre_degradation_index_high():
-    """Average hard ratio > 0.50 → index 2."""
-    conn = _mock_conn_scalar(0.60)
+    """avg_compounds_per_driver >= 2.3 → index 2 (e.g. Barcelona: ~2.33)."""
+    conn = _mock_conn_scalar(2.60)
     result = _circuit_tyre_degradation_index(conn, circuit_id=1, race_date=date(2024, 5, 1))
     assert result == 2
 
 
 def test_circuit_tyre_degradation_index_medium():
-    """Average hard ratio between 0.30 and 0.50 (inclusive) → index 1."""
-    conn = _mock_conn_scalar(0.40)
+    """avg_compounds_per_driver in [2.1, 2.3) → index 1."""
+    conn = _mock_conn_scalar(2.20)
     result = _circuit_tyre_degradation_index(conn, circuit_id=1, race_date=date(2024, 5, 1))
     assert result == 1
 
 
 def test_circuit_tyre_degradation_index_low():
-    """Average hard ratio < 0.30 → index 0."""
-    conn = _mock_conn_scalar(0.15)
+    """avg_compounds_per_driver < 2.1 → index 0 (e.g. Monza: ~2.0)."""
+    conn = _mock_conn_scalar(1.95)
     result = _circuit_tyre_degradation_index(conn, circuit_id=1, race_date=date(2024, 5, 1))
     assert result == 0
 
@@ -471,17 +471,17 @@ def test_circuit_tyre_degradation_index_no_data():
 
 
 def test_circuit_tyre_degradation_index_boundary_low_medium():
-    """Exactly 0.30 → index 1 (medium, not low)."""
-    conn = _mock_conn_scalar(0.30)
+    """Exactly 2.1 → index 1 (medium, not low)."""
+    conn = _mock_conn_scalar(2.10)
     result = _circuit_tyre_degradation_index(conn, circuit_id=1, race_date=date(2024, 5, 1))
     assert result == 1
 
 
 def test_circuit_tyre_degradation_index_boundary_medium_high():
-    """Exactly 0.50 → index 1 (medium, not high)."""
-    conn = _mock_conn_scalar(0.50)
+    """Exactly 2.3 → index 2 (high, not medium)."""
+    conn = _mock_conn_scalar(2.30)
     result = _circuit_tyre_degradation_index(conn, circuit_id=1, race_date=date(2024, 5, 1))
-    assert result == 1
+    assert result == 2
 
 
 # ---------------------------------------------------------------------------

--- a/pipeline/tests/test_builder.py
+++ b/pipeline/tests/test_builder.py
@@ -7,8 +7,10 @@ import pandas as pd
 import pytest
 
 from pipeline.features.builder import (
+    _circuit_tyre_degradation_index,
     _constructor_avg_fp2_pace_at_circuit,
     _constructor_dnf_rate_last_season,
+    _constructor_hard_compound_avg_position,
     _constructor_standings,
     _driver_avg_position_at_circuit,
     _driver_avg_position_last_n,
@@ -328,6 +330,12 @@ def test_build_features_pre_weekend_fallback():
         elif "COUNT(*) FILTER" in sql:
             # _driver_podium_rate_at_circuit
             result.fetchone.return_value = (0, 5)
+        elif "race_tyre_data" in sql and "AVG" in sql and "constructor_id" not in sql:
+            # _circuit_tyre_degradation_index — high degradation circuit
+            result.scalar.return_value = 0.55
+        elif "race_tyre_data" in sql:
+            # _constructor_hard_compound_avg_position
+            result.scalar.return_value = 7.0
         else:
             result.scalar.return_value = 5.0
         return result
@@ -340,6 +348,8 @@ def test_build_features_pre_weekend_fallback():
     assert df.iloc[0]["driver_championship_position"] == 1
     assert df.iloc[0]["constructor_championship_position"] == 1
     assert df.iloc[0]["constructor_dnf_rate_last_season"] == pytest.approx(0.1)
+    assert df.iloc[0]["circuit_tyre_degradation_index"] == 2
+    assert df.iloc[0]["constructor_hard_compound_avg_position"] == pytest.approx(7.0)
 
 
 def _make_imputation_engine(sector2_values: list, fp2_values: list):
@@ -381,6 +391,9 @@ def _make_imputation_engine(sector2_values: list, fp2_values: list):
             result.scalar.return_value = next(sector2_calls, None)
         elif "best_lap_ms" in sql and "session_times" in sql:
             result.scalar.return_value = next(fp2_calls, None)
+        elif "race_tyre_data" in sql:
+            # tyre features — return neutral values for imputation tests
+            result.scalar.return_value = None
         else:
             result.scalar.return_value = 5.0
         return result
@@ -422,3 +435,68 @@ def test_sector_fp2_imputation_all_null_defaults_to_one():
         assert v == pytest.approx(1.0)
     for v in df["constructor_avg_fp2_pace_at_circuit"]:
         assert v == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Tyre degradation index
+# ---------------------------------------------------------------------------
+
+
+def test_circuit_tyre_degradation_index_high():
+    """Average hard ratio > 0.50 → index 2."""
+    conn = _mock_conn_scalar(0.60)
+    result = _circuit_tyre_degradation_index(conn, circuit_id=1, race_date=date(2024, 5, 1))
+    assert result == 2
+
+
+def test_circuit_tyre_degradation_index_medium():
+    """Average hard ratio between 0.30 and 0.50 (inclusive) → index 1."""
+    conn = _mock_conn_scalar(0.40)
+    result = _circuit_tyre_degradation_index(conn, circuit_id=1, race_date=date(2024, 5, 1))
+    assert result == 1
+
+
+def test_circuit_tyre_degradation_index_low():
+    """Average hard ratio < 0.30 → index 0."""
+    conn = _mock_conn_scalar(0.15)
+    result = _circuit_tyre_degradation_index(conn, circuit_id=1, race_date=date(2024, 5, 1))
+    assert result == 0
+
+
+def test_circuit_tyre_degradation_index_no_data():
+    """No prior tyre data for circuit → neutral fallback of 1."""
+    conn = _mock_conn_scalar(None)
+    result = _circuit_tyre_degradation_index(conn, circuit_id=1, race_date=date(2024, 5, 1))
+    assert result == 1
+
+
+def test_circuit_tyre_degradation_index_boundary_low_medium():
+    """Exactly 0.30 → index 1 (medium, not low)."""
+    conn = _mock_conn_scalar(0.30)
+    result = _circuit_tyre_degradation_index(conn, circuit_id=1, race_date=date(2024, 5, 1))
+    assert result == 1
+
+
+def test_circuit_tyre_degradation_index_boundary_medium_high():
+    """Exactly 0.50 → index 1 (medium, not high)."""
+    conn = _mock_conn_scalar(0.50)
+    result = _circuit_tyre_degradation_index(conn, circuit_id=1, race_date=date(2024, 5, 1))
+    assert result == 1
+
+
+# ---------------------------------------------------------------------------
+# Constructor hard compound avg position
+# ---------------------------------------------------------------------------
+
+
+def test_constructor_hard_compound_avg_position_returns_value():
+    conn = _mock_conn_scalar(6.5)
+    result = _constructor_hard_compound_avg_position(conn, constructor_id=1, race_date=date(2024, 5, 1))
+    assert result == pytest.approx(6.5)
+
+
+def test_constructor_hard_compound_avg_position_no_hard_circuits():
+    """No results at high-degradation circuits → None."""
+    conn = _mock_conn_scalar(None)
+    result = _constructor_hard_compound_avg_position(conn, constructor_id=1, race_date=date(2024, 5, 1))
+    assert result is None

--- a/pipeline/tests/test_builder.py
+++ b/pipeline/tests/test_builder.py
@@ -422,7 +422,8 @@ def test_sector_fp2_imputation_mixed_null():
 
 
 def test_sector_fp2_imputation_all_null_defaults_to_one():
-    """When no driver has any historical data (new circuit), all values default to 1.0."""
+    """When no driver has any historical data (new circuit), pace-ratio values default
+    to 1.0 and constructor_hard_compound_avg_position defaults to 10.0."""
     engine = _make_imputation_engine(
         sector2_values=[None, None],
         fp2_values=[None, None],
@@ -431,10 +432,13 @@ def test_sector_fp2_imputation_all_null_defaults_to_one():
     assert len(df) == 2
     assert df["driver_avg_sector2_time_at_circuit"].notna().all()
     assert df["constructor_avg_fp2_pace_at_circuit"].notna().all()
+    assert df["constructor_hard_compound_avg_position"].notna().all()
     for v in df["driver_avg_sector2_time_at_circuit"]:
         assert v == pytest.approx(1.0)
     for v in df["constructor_avg_fp2_pace_at_circuit"]:
         assert v == pytest.approx(1.0)
+    for v in df["constructor_hard_compound_avg_position"]:
+        assert v == pytest.approx(10.0)
 
 
 # ---------------------------------------------------------------------------

--- a/pipeline/tests/test_builder.py
+++ b/pipeline/tests/test_builder.py
@@ -332,7 +332,7 @@ def test_build_features_pre_weekend_fallback():
             result.fetchone.return_value = (0, 5)
         elif "race_tyre_data" in sql and "AVG" in sql and "constructor_id" not in sql:
             # _circuit_tyre_degradation_index — high degradation circuit
-            result.scalar.return_value = 0.55
+            result.scalar.return_value = 2.60
         elif "race_tyre_data" in sql:
             # _constructor_hard_compound_avg_position
             result.scalar.return_value = 7.0

--- a/pipeline/tests/test_predict.py
+++ b/pipeline/tests/test_predict.py
@@ -44,6 +44,8 @@ def _make_feature_data() -> dict:
         "constructor_dnf_rate_last_season": float(rng.uniform(0, 1)),
         "driver_avg_sector2_time_at_circuit": float(rng.uniform(1.0, 1.3)),
         "constructor_avg_fp2_pace_at_circuit": float(rng.uniform(1.0, 1.3)),
+        "circuit_tyre_degradation_index": int(rng.randint(0, 3)),
+        "constructor_hard_compound_avg_position": float(rng.uniform(1, 20)),
     }
 
 

--- a/pipeline/tests/test_train.py
+++ b/pipeline/tests/test_train.py
@@ -49,6 +49,8 @@ def _make_feature_df(n: int = 20, season: int = 2023) -> pd.DataFrame:
                 "constructor_dnf_rate_last_season": rng.uniform(0, 1),
                 "driver_avg_sector2_time_at_circuit": rng.uniform(1.0, 1.3),
                 "constructor_avg_fp2_pace_at_circuit": rng.uniform(1.0, 1.3),
+                "circuit_tyre_degradation_index": rng.randint(0, 3),
+                "constructor_hard_compound_avg_position": rng.uniform(1, 20),
                 "finish_position": rng.randint(1, 21),
                 "season": season,
             }


### PR DESCRIPTION
## Summary

- Adds `race_tyre_data` table (migration 013) storing per-driver lap counts per compound ingested from FastF1 race sessions
- New backfill script `fetch_tyre_data.py` follows the same pattern as `fetch_session_times.py`
- Two new ML features added to `builder.py`, `FEATURE_COLS`, and `_numeric_cols`:
  - `circuit_tyre_degradation_index` — ordinal 0/1/2 (low/medium/high) derived from the average proportion of HARD compound laps at a circuit historically; thresholds < 0.30 / 0.30–0.50 / > 0.50; neutral fallback `1` for new circuits
  - `constructor_hard_compound_avg_position` — constructor's historical average finish position at high-degradation circuits (HARD proportion > 0.50); `None` imputed with race-level median

## Acceptance criteria

- ✅ Tyre-related features present in feature Parquets (`circuit_tyre_degradation_index`, `constructor_hard_compound_avg_position`)
- ✅ `circuit_tyre_degradation_index` distinguishes Monza (low HARD proportion → 0) from Barcelona (high HARD proportion → 2)
- ✅ No data leakage: all SQL helpers gate on `r.date < :race_date AND r.is_completed = TRUE`
- ✅ 8 new unit tests covering all threshold boundaries, no-data fallback, and integration assertions; 193/193 tests pass

## Test plan

- [ ] Run `docker compose run --rm pipeline python -m pytest pipeline/tests/ -v` — all 193 tests pass
- [ ] Backfill tyre data: `docker compose run --rm pipeline python -m pipeline.ingest.fetch_tyre_data --season 2023`
- [ ] Rebuild features for a known race and verify both columns present in the Parquet
- [ ] Confirm `circuit_tyre_degradation_index` for Monza < Barcelona in the generated features

Closes #71