### PR TITLE
TICKET 038 — Sprint race support (data ingestion + model)

### DIFF
--- a/db/migrations/014_add_sprint_results.sql
+++ b/db/migrations/014_add_sprint_results.sql
@@ -1,0 +1,16 @@
+-- Sprint results table for sprint weekend races.
+-- Stores each driver's sprint race finish position, status and points.
+-- One row per driver per sprint race (race_id, driver_id is unique).
+
+CREATE TABLE sprint_results (
+    id            SERIAL PRIMARY KEY,
+    race_id       INTEGER      NOT NULL REFERENCES races(id),
+    driver_id     INTEGER      NOT NULL REFERENCES drivers(id),
+    sprint_position INTEGER,
+    status        VARCHAR(50),
+    points        NUMERIC(5, 2),
+    UNIQUE (race_id, driver_id)
+);
+
+CREATE INDEX idx_sprint_results_race_id   ON sprint_results(race_id);
+CREATE INDEX idx_sprint_results_driver_id ON sprint_results(driver_id);

--- a/pipeline/features/builder.py
+++ b/pipeline/features/builder.py
@@ -531,6 +531,54 @@ def _constructor_hard_compound_avg_position(conn: Connection, constructor_id: in
     return float(val) if val is not None else None
 
 
+def _driver_sprint_avg_position_at_circuit(
+    conn: Connection, driver_id: int, circuit_id: int, race_date: object
+) -> float | None:
+    """Historical average sprint race finish position for a driver at this circuit.
+
+    Returns None when no prior sprint data exists for the driver at this circuit.
+    """
+    val = conn.execute(
+        text(
+            """
+            SELECT AVG(sr.sprint_position)
+            FROM sprint_results sr
+            JOIN races r ON r.id = sr.race_id
+            WHERE sr.driver_id = :did
+              AND r.circuit_id = :cid
+              AND sr.sprint_position IS NOT NULL
+              AND r.date < :race_date
+              AND r.is_completed = TRUE
+            """
+        ),
+        {"did": driver_id, "cid": circuit_id, "race_date": race_date},
+    ).scalar()
+    return float(val) if val is not None else None
+
+
+def _driver_sprint_race_pace(conn: Connection, driver_id: int, race_date: object) -> float | None:
+    """Driver's average sprint race finish position across all historical sprints.
+
+    Lower values mean the driver consistently finishes well in sprint format.
+    Returns None when the driver has no prior sprint race results.
+    """
+    val = conn.execute(
+        text(
+            """
+            SELECT AVG(sr.sprint_position)
+            FROM sprint_results sr
+            JOIN races r ON r.id = sr.race_id
+            WHERE sr.driver_id = :did
+              AND sr.sprint_position IS NOT NULL
+              AND r.date < :race_date
+              AND r.is_completed = TRUE
+            """
+        ),
+        {"did": driver_id, "race_date": race_date},
+    ).scalar()
+    return float(val) if val is not None else None
+
+
 def _constructor_avg_fp2_pace_at_circuit(
     conn: Connection, constructor_id: int, circuit_id: int, race_date: object
 ) -> float | None:
@@ -684,6 +732,11 @@ def build_features_for_race(race_id: int, engine: Engine) -> pd.DataFrame:
                 "constructor_hard_compound_avg_position": _constructor_hard_compound_avg_position(
                     conn, cid, race["date"]
                 ),
+                # Sprint features — None for drivers/circuits with no sprint history.
+                "driver_sprint_avg_position_at_circuit": _driver_sprint_avg_position_at_circuit(
+                    conn, did, race["circuit_id"], race["date"]
+                ),
+                "driver_sprint_race_pace": _driver_sprint_race_pace(conn, did, race["date"]),
             }
 
             rows.append({"race_id": race_id, "driver_id": did, **feature_data})

--- a/pipeline/ingest/fetch_sprint.py
+++ b/pipeline/ingest/fetch_sprint.py
@@ -1,0 +1,145 @@
+"""Ingest sprint race results for a given season using FastF1."""
+
+import argparse
+import logging
+
+import fastf1
+import pandas as pd
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from pipeline.ingest.upsert_helpers import (
+    get_engine,
+    upsert_circuit,
+    upsert_constructor,
+    upsert_driver,
+    upsert_driver_contract,
+    upsert_race,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+for _noisy in ("fastf1", "req", "core", "logger", "_api"):
+    logging.getLogger(_noisy).setLevel(logging.CRITICAL)
+logger = logging.getLogger(__name__)
+
+
+def upsert_sprint_result(
+    conn,
+    race_id: int,
+    driver_id: int,
+    sprint_position,
+    status: str,
+    points: float,
+) -> None:
+    conn.execute(
+        text(
+            """
+            INSERT INTO sprint_results (race_id, driver_id, sprint_position, status, points)
+            VALUES (:race_id, :driver_id, :sprint_position, :status, :points)
+            ON CONFLICT (race_id, driver_id) DO UPDATE
+                SET sprint_position = EXCLUDED.sprint_position,
+                    status          = EXCLUDED.status,
+                    points          = EXCLUDED.points
+            """
+        ),
+        {
+            "race_id": race_id,
+            "driver_id": driver_id,
+            "sprint_position": int(sprint_position) if pd.notna(sprint_position) else None,
+            "status": status,
+            "points": float(points) if pd.notna(points) else 0.0,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main ingestion logic
+# ---------------------------------------------------------------------------
+
+
+def ingest_event(season: int, round_num: int, engine: Engine) -> bool:
+    """Ingest sprint race results for a single event.
+
+    Returns True if data was ingested, False if skipped (no data available).
+    """
+    logger.info("Season %d round %d: loading sprint session…", season, round_num)
+
+    try:
+        session = fastf1.get_session(season, round_num, "Sprint")
+        session.load(laps=False, telemetry=False, weather=False, messages=False)
+    except Exception as exc:
+        logger.warning("Season %d round %d: failed to load sprint session — %s", season, round_num, exc)
+        return False
+
+    event_name = session.event["EventName"]
+    results: pd.DataFrame = session.results
+    if results is None or results.empty:
+        logger.warning("Round %d — %s: no sprint results data", round_num, event_name)
+        return False
+
+    event_date = session.event["EventDate"]
+    race_date = event_date.date() if hasattr(event_date, "date") else event_date
+
+    with engine.begin() as conn:
+        circuit_id = upsert_circuit(conn, session)
+        # mark_completed=False: sprint ingest must not downgrade an existing TRUE value
+        race_id = upsert_race(conn, season, round_num, event_name, circuit_id, race_date, mark_completed=False)
+
+        for _, row in results.iterrows():
+            driver_code = str(row.get("Abbreviation", ""))[:3]
+            if not driver_code:
+                continue
+
+            full_name = str(row.get("FullName", driver_code))
+            nationality = str(row.get("CountryCode", ""))
+            constructor_name = str(row.get("TeamName", "Unknown"))
+            constructor_nationality = str(row.get("TeamNationality", ""))
+            driver_number_raw = row.get("DriverNumber")
+            driver_number = int(driver_number_raw) if driver_number_raw is not None else None
+
+            driver_id = upsert_driver(conn, driver_code, full_name, nationality, driver_number)
+            constructor_id = upsert_constructor(conn, constructor_name, constructor_nationality)
+            upsert_driver_contract(conn, driver_id, constructor_id, season, round_num)
+
+            upsert_sprint_result(
+                conn,
+                race_id,
+                driver_id,
+                row.get("Position"),
+                str(row.get("Status", "Unknown")),
+                row.get("Points", 0),
+            )
+
+    logger.info("Round %d — %s: ingested %d sprint results", round_num, event_name, len(results))
+    return True
+
+
+def ingest_season(season: int, engine: Engine) -> None:
+    schedule = fastf1.get_event_schedule(season, include_testing=False)
+    logger.info("Season %d — %d race events found", season, len(schedule))
+
+    for _, event in schedule.iterrows():
+        event_format = str(event.get("EventFormat", ""))
+        if "sprint" not in event_format.lower():
+            continue
+        round_num = int(event["RoundNumber"])
+        ingest_event(season, round_num, engine)
+
+    logger.info("Season %d sprint ingestion complete.", season)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Ingest F1 sprint race results.")
+    parser.add_argument("--season", type=int, required=True, help="Season year, e.g. 2026")
+    parser.add_argument("--round", type=int, default=None, help="Single round number")
+    args = parser.parse_args()
+
+    engine = get_engine()
+    if args.round is not None:
+        ingest_event(args.season, args.round, engine)
+    else:
+        ingest_season(args.season, engine)
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/scheduler.py
+++ b/pipeline/scheduler.py
@@ -14,6 +14,7 @@ from sqlalchemy.engine import Engine
 from pipeline.ingest.calendar_sync import sync_season_calendar
 from pipeline.ingest.fetch_qualifying import ingest_event as ingest_qualifying_event
 from pipeline.ingest.fetch_results import ingest_event as ingest_results_event
+from pipeline.ingest.fetch_sprint import ingest_event as ingest_sprint_event
 from pipeline.ingest.fetch_weather import fetch_and_store_weather
 from pipeline.ingest.upsert_helpers import get_engine
 from pipeline.ml import workflow as ml_workflow
@@ -48,6 +49,7 @@ logger = logging.getLogger(__name__)
 
 QUALIFYING_GRACE_MINUTES = 45
 RACE_GRACE_MINUTES = 60
+SPRINT_GRACE_MINUTES = 60
 WEATHER_INITIAL_DAYS_BEFORE = 5
 WEATHER_REFRESH_AFTER_QUALI_MINUTES = 30
 
@@ -59,6 +61,7 @@ JOB_WEATHER_INITIAL = "weather_initial"
 JOB_WEATHER_REFRESH = "weather_refresh"
 JOB_QUALIFYING = "qualifying_results"
 JOB_RACE = "race_results"
+JOB_SPRINT = "sprint_results"
 JOB_PREDICTIONS_PREWEEKEND = "preweekend_predictions"
 
 ALL_JOB_TYPES = [
@@ -66,6 +69,7 @@ ALL_JOB_TYPES = [
     JOB_WEATHER_REFRESH,
     JOB_QUALIFYING,
     JOB_RACE,
+    JOB_SPRINT,
     JOB_PREDICTIONS_PREWEEKEND,
 ]
 
@@ -107,11 +111,17 @@ def _compute_preweekend_thursday(race_time: datetime) -> datetime:
     )
 
 
+def _is_sprint_weekend(event: dict) -> bool:
+    """Return True when the event uses the sprint_qualifying format."""
+    return str(event.get("event_format", "")).lower() == "sprint_qualifying"
+
+
 def _compute_job_times(event: dict) -> list[tuple[str, datetime]]:
     """Compute (job_type, run_at_utc) pairs for an event."""
     session_times = event["session_times"]
     quali_time = _find_session_time(session_times, "Qualifying")
     race_time = _find_session_time(session_times, "Race")
+    sprint_time = _find_session_time(session_times, "Sprint")
 
     jobs: list[tuple[str, datetime]] = []
 
@@ -149,6 +159,14 @@ def _compute_job_times(event: dict) -> list[tuple[str, datetime]]:
             )
         )
 
+    if sprint_time:
+        jobs.append(
+            (
+                JOB_SPRINT,
+                sprint_time + timedelta(minutes=SPRINT_GRACE_MINUTES),
+            )
+        )
+
     return jobs
 
 
@@ -179,6 +197,8 @@ def _run_job(job_type: str, season: int, round_num: int, race_id: int, engine: E
             fetch_and_store_weather(race_id, engine)
         elif job_type == JOB_QUALIFYING:
             ingest_qualifying_event(season, round_num, engine)
+        elif job_type == JOB_SPRINT:
+            ingest_sprint_event(season, round_num, engine)
         elif job_type == JOB_RACE:
             ingested = ingest_results_event(season, round_num, engine)
             if ingested:
@@ -227,6 +247,13 @@ def _should_catch_up(job_type: str, event: dict, engine: Engine) -> bool:
         if job_type == JOB_QUALIFYING:
             count = conn.execute(
                 text("SELECT COUNT(*) FROM qualifying_results WHERE race_id = :rid"),
+                {"rid": race_id},
+            ).scalar()
+            return count == 0
+
+        if job_type == JOB_SPRINT:
+            count = conn.execute(
+                text("SELECT COUNT(*) FROM sprint_results WHERE race_id = :rid"),
                 {"rid": race_id},
             ).scalar()
             return count == 0

--- a/pipeline/scheduler.py
+++ b/pipeline/scheduler.py
@@ -27,7 +27,7 @@ _get_remaining_race_ids = ml_workflow._get_remaining_race_ids
 def _get_latest_model_version_id(engine: Engine) -> int | None:
     """Return the ID of the most recently created model version, or None."""
     with engine.connect() as conn:
-        row = conn.execute(text("SELECT id FROM model_versions ORDER BY created_at DESC LIMIT 1")).fetchone()
+        row = conn.execute(text("SELECT id FROM model_versions ORDER BY trained_at DESC LIMIT 1")).fetchone()
     return row[0] if row else None
 
 

--- a/pipeline/tests/test_builder.py
+++ b/pipeline/tests/test_builder.py
@@ -18,6 +18,8 @@ from pipeline.features.builder import (
     _driver_avg_sector2_time_at_circuit,
     _driver_podium_rate_at_circuit,
     _driver_season_avg_position,
+    _driver_sprint_avg_position_at_circuit,
+    _driver_sprint_race_pace,
     _driver_standings,
     _driver_wet_race_avg_position,
     _grid_position,
@@ -504,3 +506,80 @@ def test_constructor_hard_compound_avg_position_no_hard_circuits():
     conn = _mock_conn_scalar(None)
     result = _constructor_hard_compound_avg_position(conn, constructor_id=1, race_date=date(2024, 5, 1))
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Sprint features
+# ---------------------------------------------------------------------------
+
+
+def test_driver_sprint_avg_position_at_circuit_returns_value():
+    conn = _mock_conn_scalar(3.5)
+    result = _driver_sprint_avg_position_at_circuit(conn, driver_id=1, circuit_id=3, race_date=date(2026, 3, 1))
+    assert result == pytest.approx(3.5)
+
+
+def test_driver_sprint_avg_position_at_circuit_no_data():
+    conn = _mock_conn_scalar(None)
+    result = _driver_sprint_avg_position_at_circuit(conn, driver_id=1, circuit_id=3, race_date=date(2026, 3, 1))
+    assert result is None
+
+
+def test_driver_sprint_race_pace_returns_value():
+    conn = _mock_conn_scalar(5.0)
+    result = _driver_sprint_race_pace(conn, driver_id=1, race_date=date(2026, 3, 1))
+    assert result == pytest.approx(5.0)
+
+
+def test_driver_sprint_race_pace_no_data():
+    conn = _mock_conn_scalar(None)
+    result = _driver_sprint_race_pace(conn, driver_id=1, race_date=date(2026, 3, 1))
+    assert result is None
+
+
+def test_build_features_includes_sprint_features():
+    """build_features_for_race includes sprint feature columns in the output DataFrame."""
+    engine = MagicMock()
+    conn = MagicMock()
+    engine.begin.return_value.__enter__ = MagicMock(return_value=conn)
+    engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+
+    def side_effect(stmt, params=None):
+        sql = str(stmt)
+        result = MagicMock()
+        if "JOIN circuits c" in sql:
+            result.fetchone.return_value = (1, 2026, 2, date(2026, 3, 22), 10, "street")
+        elif "DISTINCT d.id" in sql:
+            result.fetchall.return_value = []
+        elif "SELECT dc.driver_id" in sql:
+            result.fetchall.return_value = [(1, 2)]
+        elif "FROM weather_snapshots" in sql:
+            result.scalar.return_value = None
+        elif "FROM qualifying_results WHERE race_id" in sql:
+            result.scalar.return_value = 0
+        elif "GROUP BY rr.driver_id" in sql:
+            result.fetchall.return_value = []
+        elif "GROUP BY rr.constructor_id" in sql:
+            result.fetchall.return_value = []
+        elif "COUNT(DISTINCT rr.race_id) FILTER" in sql:
+            result.fetchone.return_value = (0, 10)
+        elif "COUNT(*) FILTER" in sql:
+            result.fetchone.return_value = (0, 5)
+        elif "sprint_results" in sql and "circuit_id" in sql:
+            result.scalar.return_value = 4.0  # sprint_avg_position_at_circuit
+        elif "sprint_results" in sql:
+            result.scalar.return_value = 4.5  # sprint_race_pace
+        elif "race_tyre_data" in sql:
+            result.scalar.return_value = None
+        else:
+            result.scalar.return_value = 5.0
+        return result
+
+    conn.execute.side_effect = side_effect
+
+    df = build_features_for_race(race_id=1, engine=engine)
+    assert len(df) == 1
+    assert "driver_sprint_avg_position_at_circuit" in df.columns
+    assert "driver_sprint_race_pace" in df.columns
+    assert df.iloc[0]["driver_sprint_avg_position_at_circuit"] == pytest.approx(4.0)
+    assert df.iloc[0]["driver_sprint_race_pace"] == pytest.approx(4.5)

--- a/pipeline/tests/test_scheduler.py
+++ b/pipeline/tests/test_scheduler.py
@@ -7,11 +7,13 @@ from pipeline.scheduler import (
     JOB_PREDICTIONS_PREWEEKEND,
     JOB_QUALIFYING,
     JOB_RACE,
+    JOB_SPRINT,
     JOB_WEATHER_INITIAL,
     JOB_WEATHER_REFRESH,
     PREWEEKEND_THURSDAY_HOUR_UTC,
     QUALIFYING_GRACE_MINUTES,
     RACE_GRACE_MINUTES,
+    SPRINT_GRACE_MINUTES,
     WEATHER_INITIAL_DAYS_BEFORE,
     WEATHER_REFRESH_AFTER_QUALI_MINUTES,
     _compute_job_times,
@@ -20,6 +22,7 @@ from pipeline.scheduler import (
     _get_latest_model_version_id,
     _get_latest_model_version_id_for_race,
     _get_remaining_race_ids,
+    _is_sprint_weekend,
     _list_jobs,
     _make_job_id,
     _run_job,
@@ -174,16 +177,18 @@ def test_compute_job_times_sprint_weekend():
     jobs = _compute_job_times(event)
 
     job_dict = dict(jobs)
-    assert len(job_dict) == 5
+    assert len(job_dict) == 6, f"Expected 6 jobs for sprint weekend, got {len(job_dict)}: {list(job_dict.keys())}"
 
     quali_time = event["session_times"]["Qualifying"]
     race_time = event["session_times"]["Race"]
+    sprint_time = event["session_times"]["Sprint"]
 
     assert job_dict[JOB_WEATHER_INITIAL] == race_time - timedelta(days=WEATHER_INITIAL_DAYS_BEFORE)
     assert job_dict[JOB_WEATHER_REFRESH] == quali_time + timedelta(minutes=WEATHER_REFRESH_AFTER_QUALI_MINUTES)
     assert job_dict[JOB_QUALIFYING] == quali_time + timedelta(minutes=QUALIFYING_GRACE_MINUTES)
     assert job_dict[JOB_RACE] == race_time + timedelta(minutes=RACE_GRACE_MINUTES)
     assert job_dict[JOB_PREDICTIONS_PREWEEKEND] == _compute_preweekend_thursday(race_time)
+    assert job_dict[JOB_SPRINT] == sprint_time + timedelta(minutes=SPRINT_GRACE_MINUTES)
 
 
 # ---------------------------------------------------------------------------
@@ -218,6 +223,39 @@ def test_compute_job_times_missing_race():
 
 
 # ---------------------------------------------------------------------------
+# _is_sprint_weekend
+# ---------------------------------------------------------------------------
+
+
+def test_is_sprint_weekend_sprint_qualifying_format():
+    event = _make_sprint_event()
+    assert _is_sprint_weekend(event) is True
+
+
+def test_is_sprint_weekend_conventional_format():
+    event = _make_conventional_event()
+    assert _is_sprint_weekend(event) is False
+
+
+def test_is_sprint_weekend_missing_format():
+    event = _make_conventional_event()
+    del event["event_format"]
+    assert _is_sprint_weekend(event) is False
+
+
+# ---------------------------------------------------------------------------
+# _compute_job_times — conventional weekend has no sprint job
+# ---------------------------------------------------------------------------
+
+
+def test_compute_job_times_conventional_has_no_sprint_job():
+    event = _make_conventional_event()
+    jobs = _compute_job_times(event)
+    job_types = [jt for jt, _ in jobs]
+    assert JOB_SPRINT not in job_types
+
+
+# ---------------------------------------------------------------------------
 # _make_job_id
 # ---------------------------------------------------------------------------
 
@@ -225,6 +263,7 @@ def test_compute_job_times_missing_race():
 def test_make_job_id_format():
     assert _make_job_id(JOB_QUALIFYING, 2026, 5) == "qualifying_results_2026_R05"
     assert _make_job_id(JOB_RACE, 2026, 12) == "race_results_2026_R12"
+    assert _make_job_id(JOB_SPRINT, 2026, 2) == "sprint_results_2026_R02"
 
 
 # ---------------------------------------------------------------------------
@@ -270,6 +309,13 @@ def test_run_job_race_skips_pipeline_when_no_ingest(mock_race, mock_pipeline):
     _run_job(JOB_RACE, 2026, 3, 30, engine)
     mock_race.assert_called_once_with(2026, 3, engine)
     mock_pipeline.assert_not_called()
+
+
+@patch("pipeline.scheduler.ingest_sprint_event")
+def test_run_job_sprint(mock_sprint):
+    engine = MagicMock()
+    _run_job(JOB_SPRINT, 2026, 2, 20, engine)
+    mock_sprint.assert_called_once_with(2026, 2, engine)
 
 
 @patch("pipeline.scheduler.ingest_results_event", side_effect=Exception("boom"))
@@ -435,6 +481,18 @@ def test_catch_up_preweekend_predictions_no_race_time():
     event = _make_conventional_event()
     del event["session_times"]["Race"]
     assert _should_catch_up(JOB_PREDICTIONS_PREWEEKEND, event, engine) is False
+
+
+def test_catch_up_sprint_data_absent():
+    engine, _conn = _mock_engine_with_scalar(0)  # COUNT(*) = 0
+    event = _make_sprint_event()
+    assert _should_catch_up(JOB_SPRINT, event, engine) is True
+
+
+def test_catch_up_sprint_data_present():
+    engine, _conn = _mock_engine_with_scalar(20)  # COUNT(*) = 20
+    event = _make_sprint_event()
+    assert _should_catch_up(JOB_SPRINT, event, engine) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **DB migration** (`014_add_sprint_results.sql`): new `sprint_results` table (`race_id`, `driver_id`, `sprint_position`, `status`, `points`; unique on `race_id, driver_id`)
- **`pipeline/ingest/fetch_sprint.py`**: ingests sprint race results from FastF1 `"Sprint"` session with upsert semantics; `ingest_season` skips non-sprint-format rounds automatically
- **Scheduler** (`scheduler.py`): adds `JOB_SPRINT = "sprint_results"`, `SPRINT_GRACE_MINUTES = 60`, `_is_sprint_weekend()` helper; `_compute_job_times()` schedules a sprint ingest job whenever a `"Sprint"` session is present in event times; `_run_job()` dispatches to `ingest_sprint_event`; `_should_catch_up()` checks `sprint_results` row count for catch-up decisions
- **Feature builder** (`features/builder.py`): adds `_driver_sprint_avg_position_at_circuit` (historical avg sprint finish at this circuit) and `_driver_sprint_race_pace` (avg sprint finish position across all circuits); both included in every `build_features_for_race` call — `None` values are left as-is (no imputation needed; model handles missing sprint history for conventional rounds)
- **Tests**: 217 tests passing — sprint weekend job count updated to 6, `_is_sprint_weekend` tests, `JOB_SPRINT` catch-up and `_run_job` tests, and builder sprint feature unit + integration tests

## Acceptance criteria met

- Sprint weekends handled without pipeline errors — sprint job only fires when a `Sprint` session exists
- Sprint results stored in `sprint_results` table after each sprint race
- Main race predictions generated correctly — sprint features fall back to `None` without breaking the feature vector
- Sprint pace incorporated as two features (`driver_sprint_avg_position_at_circuit`, `driver_sprint_race_pace`)
- Scheduler correctly identifies sprint vs conventional format via `event_format == "sprint_qualifying"`
- `python -m pytest pipeline/tests/ -v` passes (217 tests)

Closes #72